### PR TITLE
Adding the ability to set the Theme as a prop on Dashbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.0.3]
+
+ - Added theme property on dashbook widget.
+
 ## [0.0.2]
 
  - Added properties API

--- a/lib/widget.dart
+++ b/lib/widget.dart
@@ -53,6 +53,9 @@ class _ChapterPreviewState extends State<_ChapterPreview> {
 
 class Dashbook extends StatefulWidget {
   final List<Story> stories = [];
+  ThemeData theme;
+
+  Dashbook({this.theme});
 
   Story storiesOf(String name) {
     final story = Story(name);
@@ -108,7 +111,7 @@ class _DashbookState extends State<Dashbook> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(routes: {
+    return MaterialApp(theme: widget.theme, routes: {
       '/': (BuildContext context) => Scaffold(
           appBar: AppBar(
             title: const Text('Dashbook'),

--- a/lib/widget.dart
+++ b/lib/widget.dart
@@ -53,7 +53,7 @@ class _ChapterPreviewState extends State<_ChapterPreview> {
 
 class Dashbook extends StatefulWidget {
   final List<Story> stories = [];
-  ThemeData theme;
+  final ThemeData theme;
 
   Dashbook({this.theme});
 


### PR DESCRIPTION
Wanted to add simple Theme support for dashbook. Our widgets are all inheriting from our base theme, so this is very important to us (otherwise every widget looks wrong in Dashbook).

usage:

`final dashbook = Dashbook(theme: MyThemeData)`