### PR TITLE
feat: add expansion tile to story list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.0.14]
+ - Changed Story List titles to expansion tiles.
+
 ## [0.0.13]
  - Fix text overflow on list properties
  

--- a/lib/src/widgets/stories_list.dart
+++ b/lib/src/widgets/stories_list.dart
@@ -20,42 +20,56 @@ class StoriesList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SideBarPanel(
-      title: 'Stories',
-      onCancel: onCancel,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          for (Story story in stories)
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Text(
+    return Theme(
+      data: Theme.of(context).copyWith(
+        dividerColor: Colors.transparent,
+      ),
+      child: SideBarPanel(
+        title: 'Stories',
+        onCancel: onCancel,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            for (Story story in stories)
+              ExpansionTile(
+                title: Text(
                   story.name,
-                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20),
-                ),
-                for (Chapter chapter in story.chapters)
-                  GestureDetector(
-                    behavior: HitTestBehavior.opaque,
-                    child: Link(
-                      label: "  ${chapter.name}",
-                      textAlign: TextAlign.left,
-                      padding: EdgeInsets.zero,
-                      height: 20,
-                      textStyle: TextStyle(
-                        fontWeight: chapter.id == selectedChapter.id
-                            ? FontWeight.bold
-                            : FontWeight.normal,
-                      ),
-                    ),
-                    onTap: () {
-                      onSelectChapter(chapter);
-                    },
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 20,
                   ),
-                SizedBox(height: 10),
-              ],
-            ),
-        ],
+                ),
+                initiallyExpanded: true,
+                children: [
+                  for (Chapter chapter in story.chapters)
+                    GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      child: Align(
+                        alignment: Alignment.centerLeft,
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16),
+                          child: Link(
+                            label: "  ${chapter.name}",
+                            textAlign: TextAlign.left,
+                            padding: EdgeInsets.zero,
+                            height: 20,
+                            textStyle: TextStyle(
+                              fontWeight: chapter.id == selectedChapter.id
+                                  ? FontWeight.bold
+                                  : FontWeight.normal,
+                            ),
+                          ),
+                        ),
+                      ),
+                      onTap: () {
+                        onSelectChapter(chapter);
+                      },
+                    ),
+                  SizedBox(height: 10),
+                ],
+              ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
The purpose of this pull request is to add the ability to expand and collapse story titles.

## Notes

By default, all of the tiles are expanded.  The children are also set to the same padding as the tile header.

## Screenshots

![image](https://user-images.githubusercontent.com/6907797/108954918-67b51200-763b-11eb-9137-1de11f76c4f5.png)
![image](https://user-images.githubusercontent.com/6907797/108954946-6d125c80-763b-11eb-83b5-97c0441f4617.png)
