### PR TITLE
Sharing preview space with properties on large screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [next]
+ - Large screens preview container share the space with the properties contaner for better visualization
+
 ## [0.1.1]
  - Fixing null theme
  - Scroll and expansion tiles state are now persisted when the stories list is closed

--- a/lib/src/widgets/helpers.dart
+++ b/lib/src/widgets/helpers.dart
@@ -4,3 +4,9 @@ bool isLargeScreen(BuildContext context) =>
     MediaQuery.of(context).size.width > 768;
 
 double iconSize(BuildContext context) => isLargeScreen(context) ? 24.0 : 48.0;
+
+double sideBarSize(BuildContext context) {
+  final screenWidth = MediaQuery.of(context).size.width;
+  final factor = isLargeScreen(context) ? 0.5 : 1;
+  return screenWidth * factor;
+}

--- a/lib/src/widgets/preview_container.dart
+++ b/lib/src/widgets/preview_container.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import './helpers.dart';
+
+class PreviewContainer extends StatelessWidget {
+  final bool usePreviewSafeArea;
+  final Widget child;
+  final bool isPropertiesOpen;
+  final Key key;
+
+  PreviewContainer({
+    required this.key,
+    required this.child,
+    required this.usePreviewSafeArea,
+    required this.isPropertiesOpen,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      top: 0,
+      bottom: 0,
+      left: 0,
+      right: (kIsWeb && isPropertiesOpen) ? sideBarSize(context) : 0,
+      child: Container(
+        decoration: BoxDecoration(
+          border: usePreviewSafeArea
+              ? Border(
+                  left: BorderSide(
+                      color: Theme.of(context).cardColor,
+                      width: iconSize(context) * 2),
+                  right: BorderSide(
+                      color: Theme.of(context).cardColor,
+                      width: iconSize(context) * 2),
+                )
+              : null,
+        ),
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/side_bar_panel.dart
+++ b/lib/src/widgets/side_bar_panel.dart
@@ -18,11 +18,9 @@ class SideBarPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final screenWidth = MediaQuery.of(context).size.width;
-    final factor = isLargeScreen(context) ? 0.5 : 1;
     return Container(
       color: Theme.of(context).cardColor,
-      width: screenWidth * factor,
+      width: sideBarSize(context),
       child: Stack(
         children: [
           Positioned.fill(

--- a/lib/src/widgets/widget.dart
+++ b/lib/src/widgets/widget.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
 
 import '../platform_utils/platform_utils.dart';
+import './preview_container.dart';
 import './properties_container.dart';
 import './stories_list.dart';
 import './icon.dart';
@@ -149,23 +150,11 @@ class _DashbookState extends State<Dashbook> {
               child: Stack(
                 children: [
                   if (_currentChapter != null)
-                    Positioned.fill(
-                      child: Container(
-                        decoration: BoxDecoration(
-                          border: !widget.usePreviewSafeArea
-                              ? null
-                              : Border(
-                                  left: BorderSide(
-                                      color: Theme.of(context).cardColor,
-                                      width: iconSize(context) * 2),
-                                  right: BorderSide(
-                                      color: Theme.of(context).cardColor,
-                                      width: iconSize(context) * 2),
-                                ),
-                        ),
-                        child: chapterWidget,
-                      ),
+                    PreviewContainer(
                       key: Key(_currentChapter!.id),
+                      child: chapterWidget!,
+                      usePreviewSafeArea: widget.usePreviewSafeArea,
+                      isPropertiesOpen: _currentView == CurrentView.PROPERTIES,
                     ),
                   Positioned(
                     right: 10,


### PR DESCRIPTION
The properties container was floating on top of the preview container. On large screens we can instead share that space, so the changes made on the property can be easily saw in realtime.

On small screens, the old behavior is kept.


https://user-images.githubusercontent.com/835641/115450409-3ba8ae00-a1f2-11eb-8068-4fc2f6e33a42.mov

